### PR TITLE
Initialize fs in _fetch_table

### DIFF
--- a/app/api/metadata.py
+++ b/app/api/metadata.py
@@ -77,7 +77,8 @@ def _fetch_table(
     record: bool = False,
     filters: Union[list, None] = None,
 ) -> Choosable:
-    fs = settings.FILE_SYSTEMS["aws_s3"]
+    fs_kwargs = settings.FILE_SYSTEMS["aws_s3"]
+    fs = fsspec.filesystem(**fs_kwargs)
     # Clears cache everytime
     fs.invalidate_cache(settings.METADATA_BUCKET)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -108,11 +108,12 @@ TOKEN = os.environ.get("OOI_TOKEN", None)
 
 # File Systems Configurations
 FILE_SYSTEMS = {
-    "minio_s3": fsspec.filesystem(
-        "s3", client_kwargs={"endpoint_url": "http://minio:9000"}
+    "minio_s3": dict(
+        protocol="s3",
+        client_kwargs={"endpoint_url": "http://minio:9000"}
     ),
-    "aws_s3": fsspec.filesystem(
-        "s3",
+    "aws_s3": dict(
+        protocol="s3",
         skip_instance_cache=True,
         use_listings_cache=False,
         config_kwargs={"max_pool_connections": 1000},


### PR DESCRIPTION
## Overview

This PR initializes fs everytime `_fetch_table` is called in the hopes to not break metadata service when meta is updated.