### PR TITLE
Update s3 bucket names

### DIFF
--- a/app/api/metadata.py
+++ b/app/api/metadata.py
@@ -223,7 +223,7 @@ def _get_data_availability(
     average: bool,
     resolution: Literal['hourly', 'daily', 'monthly'] = 'daily',
 ):
-    url_template = 'https://raw.githubusercontent.com/ooi-data/data_availability/main/{resolution}/{ref}'.format
+    url_template = 'https://raw.githubusercontent.com/ooi-data-prod/data_availability/main/{resolution}/{ref}'.format
     request_url = url_template(resolution=resolution, ref=ref)
     response = requests.get(request_url)
     if response.status_code == 200:
@@ -820,7 +820,7 @@ async def get_instruments_catalog(version: bool = Depends(_check_version)):
         if "legacy_catalog" not in META:
             fs = fsspec.filesystem('s3')
             with fs.open(
-                os.path.join('ooi-metadata', 'legacy_catalog.json')
+                os.path.join('ooi-metadata-prod', 'legacy_catalog.json')
             ) as f:
                 results = json.load(f)
                 META.update({"legacy_catalog": results})

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -61,11 +61,11 @@ class Settings(BaseSettings):
         "GOOGLE_SERVICE_JSON",
         "",
     )
-    DATA_BUCKET = 'ooi-data'
+    DATA_BUCKET = 'ooi-data-prod'
 
     # Data sources
-    METADATA_SOURCE = "s3://ooi-metadata"
-    METADATA_BUCKET = "ooi-metadata"
+    METADATA_SOURCE = "s3://ooi-metadata-prod"
+    METADATA_BUCKET = "ooi-metadata-prod"
 
 
 settings = Settings()
@@ -126,7 +126,7 @@ GOOGLE_SERVICE_JSON = os.environ.get(
     "GOOGLE_SERVICE_JSON",
     "",
 )
-DATA_BUCKET = 'ooi-data'
+DATA_BUCKET = 'ooi-data-prod'
 
 # Data sources
-METADATA_SOURCE = "s3://ooi-metadata"
+METADATA_SOURCE = "s3://ooi-metadata-prod"


### PR DESCRIPTION
This PR contains changes to update the s3 bucket names from the prefect 1 harvest to the new prefect 2 harvest. These new pointers will point to buckets on the rca-data s3 buckets instead of cava. 